### PR TITLE
Fix one bug of address list length comparision in rpc.Send()

### DIFF
--- a/rpc/send.go
+++ b/rpc/send.go
@@ -97,7 +97,6 @@ func (s SendError) CanRetry() bool { return s.canRetry }
 func Send(opts Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) interface{},
 	getReply func() interface{}, context *Context) ([]interface{}, error) {
 
-	// Return error if provided addrs is less. modified by joezxy 2015/03/07
 	if len(addrs) < opts.N {
 		return nil, SendError{
 			errMsg:   fmt.Sprintf("insufficient replicas (%d) to satisfy send request of %d", len(addrs), opts.N),

--- a/rpc/send.go
+++ b/rpc/send.go
@@ -96,7 +96,9 @@ func (s SendError) CanRetry() bool { return s.canRetry }
 // number of required replies.
 func Send(opts Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) interface{},
 	getReply func() interface{}, context *Context) ([]interface{}, error) {
-	if opts.N < len(addrs) {
+
+	// Return error if provided addrs is less. modified by joezxy 2015/03/07
+	if len(addrs) < opts.N {
 		return nil, SendError{
 			errMsg:   fmt.Sprintf("insufficient replicas (%d) to satisfy send request of %d", len(addrs), opts.N),
 			canRetry: false,

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Cockroach Authors.
+// Copyright 2015 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,25 +18,17 @@
 package rpc
 
 import (
-	"net"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/util"
 )
 
 func TestInvalidAddrLength(t *testing.T) {
-	testAddrs := []net.Addr{
-		util.MakeRawAddr("tcp", "127.0.0.1:8080"),
-		util.MakeRawAddr("tcp", "127.0.0.1:8081"),
-		util.MakeRawAddr("tcp", "127.0.0.1:8082"),
-	}
 
-	testSendOption := Options{
-		N: 5,
-	}
+	// The provided addrs is nil, so its length will be always
+	// less than the specified response number
+	ret, err := Send(Options{N: 1}, "", nil, nil, nil, nil)
 
-	ret, _ := Send(testSendOption, "", testAddrs, nil, nil, nil)
-	if ret != nil {
-		t.Fatalf("Shorter addrs should have nil and SendError return")
+	// the expected return is nil and SendError
+	if _, ok := err.(SendError); !ok || ret != nil {
+		t.Fatalf("Shorter addrs should return nil and SendError.")
 	}
 }

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -1,0 +1,42 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: joezxy (joe.zxy@foxmail.com)
+
+package rpc
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+func TestInvalidAddrLength(t *testing.T) {
+	testAddrs := []net.Addr{
+		util.MakeRawAddr("tcp", "127.0.0.1:8080"),
+		util.MakeRawAddr("tcp", "127.0.0.1:8081"),
+		util.MakeRawAddr("tcp", "127.0.0.1:8082"),
+	}
+
+	testSendOption := Options{
+		N: 5,
+	}
+
+	ret, _ := Send(testSendOption, "", testAddrs, nil, nil, nil)
+	if ret != nil {
+		t.Fatalf("Shorter addrs should have nil and SendError return")
+	}
+}


### PR DESCRIPTION
Suppose there are 5 replicas, and requires 3 successful responses.
In the existing code: if opts.N < len(addrs) , it will always fall into error branch.
It should be modified to: if len(addrs) < opts.N
